### PR TITLE
Stability improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+CLAUDE.md
+shape_geoms/
+velocities/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 CLAUDE.md
 shape_geoms/
 velocities/
+vel_pys/

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -264,8 +264,11 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     if (coord == m_dumpij)
         debugView = v->makeNew();
     Histogram hist = histogram(v, Dimension::Id::Z, debugView, "Before");
-    if (removeFliers(v, hist))
-        hist = histogram(v, Dimension::Id::Z, debugView, "Before");
+    for (int pass = 0; pass < 3; ++pass)
+        if (!removeFliers(v, hist))
+            break;
+        else
+            hist = histogram(v, Dimension::Id::Z, debugView, "Before");
 
     PointViewPtr slice = hist[hist.size() - 1];
     if (slice->empty())
@@ -306,8 +309,11 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     if (coord == m_dumpij)
         debugView = v->makeNew();
     hist = histogram(v, Dimension::Id::Z, debugView, "After");
-    if (removeFliers(v, hist))
-        hist = histogram(v, Dimension::Id::Z, debugView, "After");
+    for (int pass = 0; pass < 3; ++pass)
+        if (!removeFliers(v, hist))
+            break;
+        else
+            hist = histogram(v, Dimension::Id::Z, debugView, "After");
     slice = hist[hist.size() - 1];
     if (slice->empty())
         return false;
@@ -340,9 +346,10 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     std::vector<ShapePair> shapes = matchShapes(bg, ag, spread);
     if (shapes.empty())
         return false;
-    auto [mean, median] = calculateOffset(bg, ag, shapes);
+    auto [mean, median, rmsResidual] = calculateOffset(bg, ag, shapes);
     offset = mean;
     m_field.setMedianOffset(coord, median);
+    m_field.setMatchQuality(coord, shapes.size(), rmsResidual);
 
 
 
@@ -432,7 +439,7 @@ std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag, double sprea
 }
 
 
-std::pair<Point, Point> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
+std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
     const std::vector<ShapePair>& shapes)
 {
     std::vector<double> pairX, pairY, pairZ;
@@ -468,7 +475,16 @@ std::pair<Point, Point> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
     Point mean { sumX / n, sumY / n, sumZ / n };
     Point median { calcMedian(pairX), calcMedian(pairY), calcMedian(pairZ) };
 
-    return { mean, median };
+    double rmsResidual = 0;
+    for (size_t i = 0; i < n; ++i)
+    {
+        double dx = pairX[i] - mean.x;
+        double dy = pairY[i] - mean.y;
+        rmsResidual += dx * dx + dy * dy;
+    }
+    rmsResidual = std::sqrt(rmsResidual / n);
+
+    return { mean, median, rmsResidual };
 }
 
 
@@ -611,20 +627,22 @@ void Atlas::writeTiff(const std::string& filename)
 
     gdal::registerDrivers();
     gdal::Raster raster(filename, "GTiff", "EPSG:32624", pixelToPos);
-    gdal::GDALError err = raster.open(xsize, ysize, 8,
+    gdal::GDALError err = raster.open(xsize, ysize, 10,
         Dimension::Type::Float, -9999, pdal::StringList());
 
     if (err != gdal::GDALError::None)
         throwError(raster.errorMsg());
     {
-        raster.writeBand(m_field.xdata(),       -9999.0, 1, "X");
-        raster.writeBand(m_field.ydata(),       -9999.0, 2, "Y");
-        raster.writeBand(m_field.zdata(),       -9999.0, 3, "Z");
-        raster.writeBand(m_field.bdata(),       -9999.0, 4, "BEFORE");
-        raster.writeBand(m_field.adata(),       -9999.0, 5, "AFTER");
-        raster.writeBand(m_field.medianXdata(), -9999.0, 6, "MEDIAN_X");
-        raster.writeBand(m_field.medianYdata(), -9999.0, 7, "MEDIAN_Y");
-        raster.writeBand(m_field.medianZdata(), -9999.0, 8, "MEDIAN_Z");
+        raster.writeBand(m_field.xdata(),            -9999.0, 1,  "X");
+        raster.writeBand(m_field.ydata(),            -9999.0, 2,  "Y");
+        raster.writeBand(m_field.zdata(),            -9999.0, 3,  "Z");
+        raster.writeBand(m_field.bdata(),            -9999.0, 4,  "BEFORE");
+        raster.writeBand(m_field.adata(),            -9999.0, 5,  "AFTER");
+        raster.writeBand(m_field.medianXdata(),      -9999.0, 6,  "MEDIAN_X");
+        raster.writeBand(m_field.medianYdata(),      -9999.0, 7,  "MEDIAN_Y");
+        raster.writeBand(m_field.medianZdata(),      -9999.0, 8,  "MEDIAN_Z");
+        raster.writeBand(m_field.matchCountData(),   -9999.0, 9,  "MATCH_COUNT");
+        raster.writeBand(m_field.rmsResidualData(),  -9999.0, 10, "RMS_RESIDUAL");
     }
 }
 

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -14,6 +14,7 @@
 #include "Draw.hpp"
 
 #include <math.h>
+#include <numeric>
 
 #include <pdal/private/gdal/GDALUtils.hpp>
 #include <pdal/private/gdal/Raster.hpp>
@@ -338,7 +339,9 @@ bool Atlas::process(Coord coord, Point& offset)
     std::vector<ShapePair> shapes = matchShapes(bg, ag);
     if (shapes.empty())
         return false;
-    offset = calculateOffset(bg, ag, shapes);
+    auto [mean, median] = calculateOffset(bg, ag, shapes);
+    offset = mean;
+    m_field.setMedianOffset(coord, median);
 
 
 
@@ -427,16 +430,11 @@ std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag)
 }
 
 
-Point Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
+std::pair<Point, Point> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
     const std::vector<ShapePair>& shapes)
 {
-    double centerX = 0;
-    double centerY = 0;
-    double centerZ = 0;
-    double minX = 0;
-    double minY = 0;
-    double maxX = 0;
-    double maxY = 0;
+    std::vector<double> pairX, pairY, pairZ;
+
     for (const ShapePair& sp : shapes)
     {
         Point bCenter, bHigh;
@@ -445,39 +443,30 @@ Point Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
         pdal::BOX2D bExtent = bg->location(sp.first, bCenter, bHigh);
         pdal::BOX2D aExtent = ag->location(sp.second, aCenter, aHigh);
 
-        centerX += aCenter.x - bCenter.x;
-        centerY += aCenter.y - bCenter.y;
-        centerZ += aCenter.z - bCenter.z;
-        minX += aExtent.minx - bExtent.minx,
-        minY += aExtent.miny - bExtent.miny;
-        maxX += aExtent.maxx - bExtent.maxx;
-        maxY += aExtent.maxy - bExtent.maxy;
-
+        pairX.push_back(((aCenter.x - bCenter.x) +
+                         (aExtent.minx - bExtent.minx) +
+                         (aExtent.maxx - bExtent.maxx)) / 3.0);
+        pairY.push_back(((aCenter.y - bCenter.y) +
+                         (aExtent.miny - bExtent.miny) +
+                         (aExtent.maxy - bExtent.maxy)) / 3.0);
+        pairZ.push_back(aCenter.z - bCenter.z);
     }
-    centerX /= shapes.size();
-    centerY /= shapes.size();
-    centerZ /= shapes.size();
-    minX /= shapes.size();
-    minY /= shapes.size();
-    maxX /= shapes.size();
-    maxY /= shapes.size();
-    double totalX = (centerX + minX + maxX) / 3;
-    double totalY = (centerY + minY + maxY) / 3;
-    double totalZ = centerZ;
 
-    /**
-    auto print = [](const std::string& s, double x, double y)
-    {
-        std::cout << s << " - " << x << "/" << y << "!\n";
+    auto calcMedian = [](std::vector<double> v) -> double {
+        std::sort(v.begin(), v.end());
+        size_t n = v.size();
+        return (n % 2) ? v[n / 2] : (v[n / 2 - 1] + v[n / 2]) / 2.0;
     };
 
-    print("Center", centerX, centerY);
-    print("Min", minX, minY);
-    print("Max", maxX, maxY);
-    print("Total", totalX, totalY);
-    **/
+    double sumX = std::accumulate(pairX.begin(), pairX.end(), 0.0);
+    double sumY = std::accumulate(pairY.begin(), pairY.end(), 0.0);
+    double sumZ = std::accumulate(pairZ.begin(), pairZ.end(), 0.0);
+    size_t n = shapes.size();
 
-    return {totalX, totalY, totalZ};
+    Point mean { sumX / n, sumY / n, sumZ / n };
+    Point median { calcMedian(pairX), calcMedian(pairY), calcMedian(pairZ) };
+
+    return { mean, median };
 }
 
 
@@ -620,17 +609,20 @@ void Atlas::writeTiff(const std::string& filename)
 
     gdal::registerDrivers();
     gdal::Raster raster(filename, "GTiff", "EPSG:32624", pixelToPos);
-    gdal::GDALError err = raster.open(xsize, ysize, 5,
+    gdal::GDALError err = raster.open(xsize, ysize, 8,
         Dimension::Type::Float, -9999, pdal::StringList());
 
     if (err != gdal::GDALError::None)
         throwError(raster.errorMsg());
     {
-        raster.writeBand(m_field.xdata(), -9999.0, 1, "X");
-        raster.writeBand(m_field.ydata(), -9999.0, 2, "Y");
-        raster.writeBand(m_field.zdata(), -9999.0, 3, "Z");
-        raster.writeBand(m_field.bdata(), -9999.0, 4, "BEFORE");
-        raster.writeBand(m_field.adata(), -9999.0, 5, "AFTER");
+        raster.writeBand(m_field.xdata(),       -9999.0, 1, "X");
+        raster.writeBand(m_field.ydata(),       -9999.0, 2, "Y");
+        raster.writeBand(m_field.zdata(),       -9999.0, 3, "Z");
+        raster.writeBand(m_field.bdata(),       -9999.0, 4, "BEFORE");
+        raster.writeBand(m_field.adata(),       -9999.0, 5, "AFTER");
+        raster.writeBand(m_field.medianXdata(), -9999.0, 6, "MEDIAN_X");
+        raster.writeBand(m_field.medianYdata(), -9999.0, 7, "MEDIAN_Y");
+        raster.writeBand(m_field.medianZdata(), -9999.0, 8, "MEDIAN_Z");
     }
 }
 

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -86,7 +86,9 @@ void Atlas::addArgs()
     m_args.add("topfrac", "Top fraction of points by Z used for surface slice (default 0.5)",
         m_dumpfrac, 0.5);
     m_args.add("minshape", "Minimum shape size in grid cells; smaller shapes are dropped "
-        "before matching (default 2)", m_minShape, 2);
+        "before matching (default 1, disables filter)", m_minShape, 1);
+    m_args.add("gridlen", "Grid cell size in meters for flood-fill shape detection "
+        "(default 1.0)", m_gridLen, 1.0);
     m_args.add("tiff", "Output directory for GeoTIFF", m_tiffDir, std::string());
     m_args.add("geojson", "Output directory for shapes GeoJSON (omit to skip)",
         m_geojsonDir, std::string());
@@ -110,6 +112,8 @@ void Atlas::parse(const pdal::StringList& slist)
         fatal("'topfrac' must be a value in the range (0,1].");
     if (m_minShape < 1)
         fatal("'minshape' must be >= 1.");
+    if (m_gridLen <= 0)
+        fatal("'gridlen' must be > 0.");
 }
 
 void Atlas::run(const pdal::StringList& s)
@@ -320,10 +324,9 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
 
     // Remove shapes whose center is outside the core tile. These are pure
     // buffer-zone blobs that belong to an adjacent cell's core area.
-    const double gridLen = 2.0;
     auto inCoreBox = [&](const Shape& s, const Point& origin, const BOX2D& core) {
-        double utmX = origin.x + (s.exactCenter().x + 0.5) * gridLen;
-        double utmY = origin.y + (s.exactCenter().y + 0.5) * gridLen;
+        double utmX = origin.x + (s.exactCenter().x + 0.5) * m_gridLen;
+        double utmY = origin.y + (s.exactCenter().y + 0.5) * m_gridLen;
         return utmX >= core.minx && utmX < core.maxx &&
                utmY >= core.miny && utmY < core.maxy;
     };
@@ -599,7 +602,7 @@ GridPtr Atlas::buildGrid(pdal::PointViewPtr v, Point origin)
 
     std::sort(v->begin(), v->end(), cmp);
 
-    return GridPtr(new Grid(v, 2, origin));
+    return GridPtr(new Grid(v, m_gridLen, origin));
 }
 
 
@@ -759,10 +762,10 @@ void Atlas::writeShapeGeoJSON(const std::string& filename)
         {
             if (!firstCell) out << ",";
             firstCell = false;
-            double minx = rec.origin.x + gi.x() * 2.0;
-            double miny = rec.origin.y + gi.y() * 2.0;
-            double maxx = minx + 2.0;
-            double maxy = miny + 2.0;
+            double minx = rec.origin.x + gi.x() * m_gridLen;
+            double miny = rec.origin.y + gi.y() * m_gridLen;
+            double maxx = minx + m_gridLen;
+            double maxy = miny + m_gridLen;
             out << "[["
                 << "[" << minx << "," << miny << "],"
                 << "[" << maxx << "," << miny << "],"

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -85,6 +85,8 @@ void Atlas::addArgs()
     m_args.add("dumpij", "IJ pos in grid index to dump", m_dumpij, Coord(-1000, -1000));
     m_args.add("topfrac", "Top fraction of points by Z used for surface slice (default 0.5)",
         m_dumpfrac, 0.5);
+    m_args.add("minshape", "Minimum shape size in grid cells; smaller shapes are dropped "
+        "before matching (default 3)", m_minShape, 3);
     m_args.add("tiff", "Output directory for GeoTIFF", m_tiffDir, std::string());
     m_args.add("geojson", "Output directory for shapes GeoJSON (omit to skip)",
         m_geojsonDir, std::string());
@@ -106,6 +108,8 @@ void Atlas::parse(const pdal::StringList& slist)
         fatal("Can't specifify both 'dumpxy' and 'dumpij'.");
     if (m_dumpfrac <= 0 || m_dumpfrac > 1)
         fatal("'topfrac' must be a value in the range (0,1].");
+    if (m_minShape < 1)
+        fatal("'minshape' must be >= 1.");
 }
 
 void Atlas::run(const pdal::StringList& s)
@@ -327,7 +331,10 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     auto& bgShapes = bg->shapes();
     bgShapes.erase(
         std::remove_if(bgShapes.begin(), bgShapes.end(),
-            [&](const Shape& s){ return !inCoreBox(s, bgOrigin, box); }),
+            [&](const Shape& s){
+                return !inCoreBox(s, bgOrigin, box) ||
+                       s.size() < (size_t)m_minShape;
+            }),
         bgShapes.end());
 
     splitter = dynamic_cast<SplitterFilter *>(m_afterMgr.getStage());
@@ -368,7 +375,10 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     auto& agShapes = ag->shapes();
     agShapes.erase(
         std::remove_if(agShapes.begin(), agShapes.end(),
-            [&](const Shape& s){ return !inCoreBox(s, agOrigin, afterCore); }),
+            [&](const Shape& s){
+                return !inCoreBox(s, agOrigin, afterCore) ||
+                       s.size() < (size_t)m_minShape;
+            }),
         agShapes.end());
 
     sortShapes(bg);
@@ -469,7 +479,7 @@ std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag, double sprea
 std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
     const std::vector<ShapePair>& shapes)
 {
-    std::vector<double> pairX, pairY, pairZ;
+    std::vector<double> pairX, pairY, pairZ, weights;
 
     for (const ShapePair& sp : shapes)
     {
@@ -486,6 +496,15 @@ std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag
                          (aExtent.miny - bExtent.miny) +
                          (aExtent.maxy - bExtent.maxy)) / 3.0);
         pairZ.push_back(aCenter.z - bCenter.z);
+
+        // Weight by shape size (larger = more stable centroid) and inverse
+        // centroid distance (tighter match = more confident displacement).
+        // +1m epsilon keeps weight finite for near-perfect matches.
+        double dist = std::sqrt(std::pow(aCenter.x - bCenter.x, 2) +
+                                std::pow(aCenter.y - bCenter.y, 2));
+        double sizeW = static_cast<double>(std::min(sp.first->size(), sp.second->size()));
+        double distW = 1.0 / (dist + 1.0);
+        weights.push_back(sizeW * distW);
     }
 
     auto calcMedian = [](std::vector<double> v) -> double {
@@ -494,12 +513,17 @@ std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag
         return (n % 2) ? v[n / 2] : (v[n / 2 - 1] + v[n / 2]) / 2.0;
     };
 
-    double sumX = std::accumulate(pairX.begin(), pairX.end(), 0.0);
-    double sumY = std::accumulate(pairY.begin(), pairY.end(), 0.0);
-    double sumZ = std::accumulate(pairZ.begin(), pairZ.end(), 0.0);
+    double totalW = std::accumulate(weights.begin(), weights.end(), 0.0);
+    double sumX = 0, sumY = 0, sumZ = 0;
     size_t n = shapes.size();
+    for (size_t i = 0; i < n; ++i)
+    {
+        sumX += weights[i] * pairX[i];
+        sumY += weights[i] * pairY[i];
+        sumZ += weights[i] * pairZ[i];
+    }
 
-    Point mean { sumX / n, sumY / n, sumZ / n };
+    Point mean { sumX / totalW, sumY / totalW, sumZ / totalW };
     Point median { calcMedian(pairX), calcMedian(pairY), calcMedian(pairZ) };
 
     double rmsResidual = 0;
@@ -507,9 +531,9 @@ std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag
     {
         double dx = pairX[i] - mean.x;
         double dy = pairY[i] - mean.y;
-        rmsResidual += dx * dx + dy * dy;
+        rmsResidual += weights[i] * (dx * dx + dy * dy);
     }
-    rmsResidual = std::sqrt(rmsResidual / n);
+    rmsResidual = std::sqrt(rmsResidual / totalW);
 
     return { mean, median, rmsResidual };
 }

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -85,7 +85,10 @@ void Atlas::addArgs()
     m_args.add("dumpij", "IJ pos in grid index to dump", m_dumpij, Coord(-1000, -1000));
     m_args.add("dumpfrac", "Top Fraction to be used for dump", m_dumpfrac, .1);
     m_args.add("tiff", "Output directory for GeoTIFF", m_tiffDir, std::string());
-    m_args.add("geojson", "Output directory for shapes GeoJSON", m_geojsonDir, std::string());
+    m_args.add("geojson", "Output directory for shapes GeoJSON (omit to skip)",
+        m_geojsonDir, std::string());
+    m_args.add("svg", "Output directory for vector SVG (omit to skip)",
+        m_svgDir, std::string());
 }
 
 void Atlas::parse(const pdal::StringList& slist)
@@ -114,19 +117,26 @@ void Atlas::run(const pdal::StringList& s)
         load();
         processGrid();
         namespace fs = std::filesystem;
-        fs::path geojsonPath = m_geojsonDir.empty()
-            ? fs::path("shapes.geojson")
-            : fs::path(m_geojsonDir) / "shapes.geojson";
-        writeShapeGeoJSON(geojsonPath.string());
+        std::string stem = pdal::FileUtils::stem(m_beforeFilename) + "_" +
+            pdal::FileUtils::stem(m_afterFilename);
 
-        pdal::SplitterFilter *splitter =
-            dynamic_cast<pdal::SplitterFilter *>(m_beforeMgr.getStage());
-        writeSvg("vector.svg", splitter->extent());
-        std::string tiffStem = pdal::FileUtils::stem(m_beforeFilename) + "_" +
-            pdal::FileUtils::stem(m_afterFilename) + ".tif";
+        if (!m_geojsonDir.empty())
+        {
+            fs::path geojsonPath = fs::path(m_geojsonDir) / (stem + ".geojson");
+            writeShapeGeoJSON(geojsonPath.string());
+        }
+
+        if (!m_svgDir.empty())
+        {
+            pdal::SplitterFilter *splitter =
+                dynamic_cast<pdal::SplitterFilter *>(m_beforeMgr.getStage());
+            fs::path svgPath = fs::path(m_svgDir) / (stem + ".svg");
+            writeSvg(svgPath.string(), splitter->extent());
+        }
+
         fs::path tiffPath = m_tiffDir.empty()
-            ? fs::path(tiffStem)
-            : fs::path(m_tiffDir) / tiffStem;
+            ? fs::path(stem + ".tif")
+            : fs::path(m_tiffDir) / (stem + ".tif");
         writeTiff(tiffPath.string());
 //        read(filename);
     }
@@ -757,10 +767,13 @@ void Atlas::writeShapeGeoJSON(const std::string& filename)
                 << "[" << minx << "," << miny << "]"
                 << "]]";
         }
+        // Flip tile_j from internal Y-down to Y-up so it aligns with the
+        // map orientation in QGIS (large tile_j = north).
+        int tileJ = YCellCount - rec.tile.second - 1;
         out << "]},\"properties\":{"
             << "\"scan\":\"" << (rec.isBefore ? "before" : "after") << "\","
             << "\"tile_i\":" << rec.tile.first << ","
-            << "\"tile_j\":" << rec.tile.second << ","
+            << "\"tile_j\":" << tileJ << ","
             << "\"shape_id\":" << rec.id << ","
             << "\"size\":" << rec.indices.size() << ","
             << "\"matched\":" << (rec.matched ? "true" : "false") << ",";

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -193,7 +193,12 @@ void Atlas::processGrid()
 {
     Coord start {XCellCount / 2, YCellCount / 2};
 
-    for (int i = 0; i <= 70; ++i)
+    // Spiral must reach the farthest cell from start; process() filters
+    // out-of-bounds coords via m_field.valid().
+    int maxRadius = std::max({start.first, start.second,
+        XCellCount - start.first - 1, YCellCount - start.second - 1});
+
+    for (int i = 0; i <= maxRadius; ++i)
     {
         int y = -i;
         int x = -i;

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -13,6 +13,7 @@
 #include "Atlas.hpp"
 #include "Draw.hpp"
 
+#include <algorithm>
 #include <math.h>
 #include <numeric>
 
@@ -191,15 +192,15 @@ void Atlas::processGrid()
 
             // If this cell has an initial offset, use it, otherwise use
             // the base one.
-            std::pair<bool, Point> offInfo = m_field.initialOffset(c);
-            Point pos;
-            if (offInfo.first)
-                pos = offInfo.second;
-            else
+            auto [valid, pos, spread] = m_field.initialOffset(c);
+            if (!valid)
+            {
                 pos = m_shift;
+                spread = 3.0;
+            }
 
             // The offset is updated if processing works.
-            if (process(c, pos))
+            if (process(c, pos, spread))
                 m_field.setOffset(c, pos);
 
             // This starts in the lower left corner and goes around in
@@ -244,7 +245,7 @@ void Atlas::dumpSurrounding()
     }
 }
 
-bool Atlas::process(Coord coord, Point& offset)
+bool Atlas::process(Coord coord, Point& offset, double spread)
 {
     using namespace pdal;
 
@@ -336,7 +337,7 @@ bool Atlas::process(Coord coord, Point& offset)
     sortShapes(bg);
     sortShapes(ag);
 
-    std::vector<ShapePair> shapes = matchShapes(bg, ag);
+    std::vector<ShapePair> shapes = matchShapes(bg, ag, spread);
     if (shapes.empty())
         return false;
     auto [mean, median] = calculateOffset(bg, ag, shapes);
@@ -383,9 +384,10 @@ void Atlas::dumpShapes(GridPtr& g)
 }
 
 
-std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag)
+std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag, double spread)
 {
     std::vector<ShapePair> matches;
+    double threshold = std::clamp(spread, 1.0, 3.0);
 
     // Build a list of shape pointers
     std::list<Shape *> asp;
@@ -410,7 +412,7 @@ std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag)
                 exactMatch = it;
             }
         }
-        if (minExactDist > 2.0)
+        if (minExactDist > threshold)
             continue;
 
         if (m_dumpij == m_coord)

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -152,6 +152,7 @@ void Atlas::load()
     splitterOpts.add("length", m_len);
     splitterOpts.add("origin_x", m_origin.x);
     splitterOpts.add("origin_y", m_origin.y);
+    splitterOpts.add("overlap", m_overlap);
 
     StageCreationOptions bOps { m_beforeFilename };
     Stage& beforeReader = m_beforeMgr.makeReader(bOps);
@@ -164,6 +165,7 @@ void Atlas::load()
     afterSplitterOpts.add("length", m_len);
     afterSplitterOpts.add("origin_x", m_origin.x + m_shift.x);
     afterSplitterOpts.add("origin_y", m_origin.y + m_shift.y);
+    afterSplitterOpts.add("overlap", m_overlap);
 
     StageCreationOptions aOps { m_afterFilename };
     Stage& afterReader = m_afterMgr.makeReader(aOps);
@@ -267,12 +269,31 @@ bool Atlas::process(Coord coord, Point& offset)
     if (slice->empty())
         return false;
 
+    // box is the nominal core tile bounds (without overlap).
+    // Shift the grid origin back by m_overlap so buffer-zone points bin into
+    // negative grid indices and flood-fill can cross the tile boundary.
     BOX2D box = splitter->bounds(splitterCoord(coord));
-    Point origin { box.minx, box.miny };
+    Point bgOrigin { box.minx - m_overlap, box.miny - m_overlap };
     if (coord == m_dumpij)
         slice = debugView;
-    GridPtr bg = buildGrid(slice, origin);
+    GridPtr bg = buildGrid(slice, bgOrigin);
     bg->findShapes(2);
+
+    // Remove shapes whose center is outside the core tile. These are pure
+    // buffer-zone blobs that belong to an adjacent cell's core area.
+    const double gridLen = 2.0;
+    auto inCoreBox = [&](const Shape& s, const Point& origin, const BOX2D& core) {
+        double utmX = origin.x + (s.exactCenter().x + 0.5) * gridLen;
+        double utmY = origin.y + (s.exactCenter().y + 0.5) * gridLen;
+        return utmX >= core.minx && utmX < core.maxx &&
+               utmY >= core.miny && utmY < core.maxy;
+    };
+
+    auto& bgShapes = bg->shapes();
+    bgShapes.erase(
+        std::remove_if(bgShapes.begin(), bgShapes.end(),
+            [&](const Shape& s){ return !inCoreBox(s, bgOrigin, box); }),
+        bgShapes.end());
 
     splitter = dynamic_cast<SplitterFilter *>(m_afterMgr.getStage());
     v = splitter->view(splitterCoord(coord));
@@ -292,14 +313,22 @@ bool Atlas::process(Coord coord, Point& offset)
     // The splitter for the "after" tiles is offset by m_shift.
     // If we want the grid to line up with the tile, the offset should be
     // m_shift, but we use an offset here that tries to account for what
-    // we've learned since we stared processing.
+    // we've learned since we started processing.
     //
     // Note here that "box" is the origin of the BEFORE points.
-    origin = { box.minx + offset.x, box.miny + offset.y };
+    BOX2D afterCore { box.minx + offset.x, box.miny + offset.y,
+                      box.maxx + offset.x, box.maxy + offset.y };
+    Point agOrigin { box.minx + offset.x - m_overlap, box.miny + offset.y - m_overlap };
     if (coord == m_dumpij)
         slice = debugView;
-    GridPtr ag = buildGrid(slice, origin);
+    GridPtr ag = buildGrid(slice, agOrigin);
     ag->findShapes(2);
+
+    auto& agShapes = ag->shapes();
+    agShapes.erase(
+        std::remove_if(agShapes.begin(), agShapes.end(),
+            [&](const Shape& s){ return !inCoreBox(s, agOrigin, afterCore); }),
+        agShapes.end());
 
 
 

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -14,6 +14,7 @@
 #include "Draw.hpp"
 
 #include <algorithm>
+#include <filesystem>
 #include <math.h>
 #include <numeric>
 
@@ -83,6 +84,8 @@ void Atlas::addArgs()
     m_args.add("dumpxy", "XY pos in UTM meters to dump", m_dumpxy, Point(-1000, -1000));
     m_args.add("dumpij", "IJ pos in grid index to dump", m_dumpij, Coord(-1000, -1000));
     m_args.add("dumpfrac", "Top Fraction to be used for dump", m_dumpfrac, .1);
+    m_args.add("tiff", "Output directory for GeoTIFF", m_tiffDir, std::string());
+    m_args.add("geojson", "Output directory for shapes GeoJSON", m_geojsonDir, std::string());
 }
 
 void Atlas::parse(const pdal::StringList& slist)
@@ -110,13 +113,21 @@ void Atlas::run(const pdal::StringList& s)
     {
         load();
         processGrid();
-        writeShapeGeoJSON("shapes.geojson");
+        namespace fs = std::filesystem;
+        fs::path geojsonPath = m_geojsonDir.empty()
+            ? fs::path("shapes.geojson")
+            : fs::path(m_geojsonDir) / "shapes.geojson";
+        writeShapeGeoJSON(geojsonPath.string());
 
         pdal::SplitterFilter *splitter =
             dynamic_cast<pdal::SplitterFilter *>(m_beforeMgr.getStage());
         writeSvg("vector.svg", splitter->extent());
-        std::string filename = pdal::FileUtils::stem(m_beforeFilename) + ".tif";
-        writeTiff(filename);
+        std::string tiffStem = pdal::FileUtils::stem(m_beforeFilename) + "_" +
+            pdal::FileUtils::stem(m_afterFilename) + ".tif";
+        fs::path tiffPath = m_tiffDir.empty()
+            ? fs::path(tiffStem)
+            : fs::path(m_tiffDir) / tiffStem;
+        writeTiff(tiffPath.string());
 //        read(filename);
     }
     catch (const pdal::pdal_error& err)

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -83,7 +83,8 @@ void Atlas::addArgs()
     m_args.add("yshift", "Y distance shift", m_shift.y).setPositional();
     m_args.add("dumpxy", "XY pos in UTM meters to dump", m_dumpxy, Point(-1000, -1000));
     m_args.add("dumpij", "IJ pos in grid index to dump", m_dumpij, Coord(-1000, -1000));
-    m_args.add("dumpfrac", "Top Fraction to be used for dump", m_dumpfrac, .1);
+    m_args.add("topfrac", "Top fraction of points by Z used for surface slice (default 0.5)",
+        m_dumpfrac, 0.5);
     m_args.add("tiff", "Output directory for GeoTIFF", m_tiffDir, std::string());
     m_args.add("geojson", "Output directory for shapes GeoJSON (omit to skip)",
         m_geojsonDir, std::string());
@@ -103,9 +104,8 @@ void Atlas::parse(const pdal::StringList& slist)
     }
     if (m_dumpxy != Point(-1000, -1000) && m_dumpij != Coord(-1000, -1000))
         fatal("Can't specifify both 'dumpxy' and 'dumpij'.");
-    if (m_dumpfrac < 0 || m_dumpfrac > 1)
-        fatal("'dumpfrac' must be a value in the range (0,1].");
-    m_dumpfrac = 1 - m_dumpfrac;
+    if (m_dumpfrac <= 0 || m_dumpfrac > 1)
+        fatal("'topfrac' must be a value in the range (0,1].");
 }
 
 void Atlas::run(const pdal::StringList& s)
@@ -297,7 +297,12 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
         else
             hist = histogram(v, Dimension::Id::Z, debugView, "Before");
 
-    PointViewPtr slice = hist[hist.size() - 1];
+    std::sort(v->begin(), v->end(),
+        [](const PointRef& a, const PointRef& b)
+            { return a.compare(Dimension::Id::Z, b); });
+    PointViewPtr slice = v->makeNew();
+    for (PointId i = (PointId)(v->size() * (1.0 - m_dumpfrac)); i < v->size(); ++i)
+        slice->appendPoint(*v, i);
     if (slice->empty())
         return false;
 
@@ -306,8 +311,6 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     // negative grid indices and flood-fill can cross the tile boundary.
     BOX2D box = splitter->bounds(splitterCoord(coord));
     Point bgOrigin { box.minx - m_overlap, box.miny - m_overlap };
-    if (coord == m_dumpij)
-        slice = debugView;
     GridPtr bg = buildGrid(slice, bgOrigin);
     bg->findShapes(2);
 
@@ -341,7 +344,12 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
             break;
         else
             hist = histogram(v, Dimension::Id::Z, debugView, "After");
-    slice = hist[hist.size() - 1];
+    std::sort(v->begin(), v->end(),
+        [](const PointRef& a, const PointRef& b)
+            { return a.compare(Dimension::Id::Z, b); });
+    slice = v->makeNew();
+    for (PointId i = (PointId)(v->size() * (1.0 - m_dumpfrac)); i < v->size(); ++i)
+        slice->appendPoint(*v, i);
     if (slice->empty())
         return false;
 
@@ -354,8 +362,6 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     BOX2D afterCore { box.minx + offset.x, box.miny + offset.y,
                       box.maxx + offset.x, box.maxy + offset.y };
     Point agOrigin { box.minx + offset.x - m_overlap, box.miny + offset.y - m_overlap };
-    if (coord == m_dumpij)
-        slice = debugView;
     GridPtr ag = buildGrid(slice, agOrigin);
     ag->findShapes(2);
 
@@ -365,10 +371,16 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
             [&](const Shape& s){ return !inCoreBox(s, agOrigin, afterCore); }),
         agShapes.end());
 
-
-
     sortShapes(bg);
     sortShapes(ag);
+
+    if (m_dumpij == coord)
+    {
+        bg->draw(0, 0, 49, 49, false);
+        ag->draw(0, 0, 49, 49, false);
+        bg->draw(0, 0, 49, 49, true);
+        ag->draw(0, 0, 49, 49, true);
+    }
 
     std::vector<ShapePair> shapes = matchShapes(bg, ag, spread);
     recordShapes(bg, true,  coord, bgOrigin, shapes);
@@ -379,24 +391,6 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     offset = mean;
     m_field.setMedianOffset(coord, median);
     m_field.setMatchQuality(coord, shapes.size(), rmsResidual);
-
-
-
-    if (m_dumpij == coord)
-    {
-        /**
-        dumpShapes(bg);
-        dumpShapes(ag);
-        **/
-
-        // Draw with point counts.
-        bg->draw(0, 0, 49, 49, false);
-        ag->draw(0, 0, 49, 49, false);
-
-        // Draw with shape numbers.
-        bg->draw(0, 0, 49, 49, true);
-        ag->draw(0, 0, 49, 49, true);
-    }
 
     return true;
 }
@@ -423,7 +417,7 @@ void Atlas::dumpShapes(GridPtr& g)
 std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag, double spread)
 {
     std::vector<ShapePair> matches;
-    double threshold = std::clamp(spread, 1.0, 3.0);
+    double threshold = std::clamp(spread, 2.5, 4.0);
 
     // Build a list of shape pointers
     std::list<Shape *> asp;
@@ -548,7 +542,7 @@ Histogram Atlas::histogram(pdal::PointViewPtr v, pdal::Dimension::Id dim,
             idx = 9;
         splits[idx]->appendPoint(*v, id);
 
-        if (debugView && (val - mn) / (mx - mn) > m_dumpfrac)
+        if (debugView && (val - mn) / (mx - mn) > (1.0 - m_dumpfrac))
             debugView->appendPoint(*v, id);
     }
 

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -410,6 +410,10 @@ std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag, double sprea
         {
             Shape *ts = *it;
 
+            double sizeRatio = (double)s.size() / ts->size();
+            if (sizeRatio > 3.0 || sizeRatio < (1.0 / 3.0))
+                continue;
+
             Point bp = s.exactCenter();
             Point ap = ts->exactCenter();
             double exactDist = std::sqrt(std::pow(bp.x - ap.x, 2) + std::pow(bp.y - ap.y, 2));

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -86,7 +86,7 @@ void Atlas::addArgs()
     m_args.add("topfrac", "Top fraction of points by Z used for surface slice (default 0.5)",
         m_dumpfrac, 0.5);
     m_args.add("minshape", "Minimum shape size in grid cells; smaller shapes are dropped "
-        "before matching (default 3)", m_minShape, 3);
+        "before matching (default 2)", m_minShape, 2);
     m_args.add("tiff", "Output directory for GeoTIFF", m_tiffDir, std::string());
     m_args.add("geojson", "Output directory for shapes GeoJSON (omit to skip)",
         m_geojsonDir, std::string());
@@ -479,7 +479,7 @@ std::vector<ShapePair> Atlas::matchShapes(GridPtr& bg, GridPtr& ag, double sprea
 std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag,
     const std::vector<ShapePair>& shapes)
 {
-    std::vector<double> pairX, pairY, pairZ, weights;
+    std::vector<double> pairX, pairY, pairZ;
 
     for (const ShapePair& sp : shapes)
     {
@@ -496,15 +496,6 @@ std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag
                          (aExtent.miny - bExtent.miny) +
                          (aExtent.maxy - bExtent.maxy)) / 3.0);
         pairZ.push_back(aCenter.z - bCenter.z);
-
-        // Weight by shape size (larger = more stable centroid) and inverse
-        // centroid distance (tighter match = more confident displacement).
-        // +1m epsilon keeps weight finite for near-perfect matches.
-        double dist = std::sqrt(std::pow(aCenter.x - bCenter.x, 2) +
-                                std::pow(aCenter.y - bCenter.y, 2));
-        double sizeW = static_cast<double>(std::min(sp.first->size(), sp.second->size()));
-        double distW = 1.0 / (dist + 1.0);
-        weights.push_back(sizeW * distW);
     }
 
     auto calcMedian = [](std::vector<double> v) -> double {
@@ -513,17 +504,12 @@ std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag
         return (n % 2) ? v[n / 2] : (v[n / 2 - 1] + v[n / 2]) / 2.0;
     };
 
-    double totalW = std::accumulate(weights.begin(), weights.end(), 0.0);
-    double sumX = 0, sumY = 0, sumZ = 0;
+    double sumX = std::accumulate(pairX.begin(), pairX.end(), 0.0);
+    double sumY = std::accumulate(pairY.begin(), pairY.end(), 0.0);
+    double sumZ = std::accumulate(pairZ.begin(), pairZ.end(), 0.0);
     size_t n = shapes.size();
-    for (size_t i = 0; i < n; ++i)
-    {
-        sumX += weights[i] * pairX[i];
-        sumY += weights[i] * pairY[i];
-        sumZ += weights[i] * pairZ[i];
-    }
 
-    Point mean { sumX / totalW, sumY / totalW, sumZ / totalW };
+    Point mean { sumX / n, sumY / n, sumZ / n };
     Point median { calcMedian(pairX), calcMedian(pairY), calcMedian(pairZ) };
 
     double rmsResidual = 0;
@@ -531,9 +517,9 @@ std::tuple<Point, Point, double> Atlas::calculateOffset(GridPtr& bg, GridPtr& ag
     {
         double dx = pairX[i] - mean.x;
         double dy = pairY[i] - mean.y;
-        rmsResidual += weights[i] * (dx * dx + dy * dy);
+        rmsResidual += dx * dx + dy * dy;
     }
-    rmsResidual = std::sqrt(rmsResidual / totalW);
+    rmsResidual = std::sqrt(rmsResidual / n);
 
     return { mean, median, rmsResidual };
 }

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -110,6 +110,7 @@ void Atlas::run(const pdal::StringList& s)
     {
         load();
         processGrid();
+        writeShapeGeoJSON("shapes.geojson");
 
         pdal::SplitterFilter *splitter =
             dynamic_cast<pdal::SplitterFilter *>(m_beforeMgr.getStage());
@@ -344,6 +345,8 @@ bool Atlas::process(Coord coord, Point& offset, double spread)
     sortShapes(ag);
 
     std::vector<ShapePair> shapes = matchShapes(bg, ag, spread);
+    recordShapes(bg, true,  coord, bgOrigin, shapes);
+    recordShapes(ag, false, coord, agOrigin, shapes);
     if (shapes.empty())
         return false;
     auto [mean, median, rmsResidual] = calculateOffset(bg, ag, shapes);
@@ -680,6 +683,78 @@ void Atlas::read(const std::string& filename)
         std::cout << "x/y/vx/vy/total " <<
             x << "/" << y << "/" << vx << "/" << vy << "/" << std::sqrt(vx * vx + vy * vy) << "!\n";
     }
+}
+
+void Atlas::recordShapes(GridPtr& g, bool isBefore, Coord tile, Point origin,
+    const std::vector<ShapePair>& matches)
+{
+    for (const Shape& s : g->shapes())
+    {
+        bool matched = false;
+        size_t matchId = std::numeric_limits<size_t>::max();
+        for (const ShapePair& sp : matches)
+        {
+            const Shape* check   = isBefore ? sp.first  : sp.second;
+            const Shape* partner = isBefore ? sp.second : sp.first;
+            if (check == &s)
+            {
+                matched = true;
+                matchId = partner->id();
+                break;
+            }
+        }
+        m_shapeRecords.push_back({s.indices(), origin, isBefore, tile, s.id(), matched, matchId});
+    }
+}
+
+
+void Atlas::writeShapeGeoJSON(const std::string& filename)
+{
+    std::ofstream out(filename);
+    out << std::fixed << std::setprecision(2);
+    out << "{\"type\":\"FeatureCollection\","
+           "\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:32624\"}},"
+           "\"features\":[\n";
+
+    bool firstFeature = true;
+    for (const ShapeRecord& rec : m_shapeRecords)
+    {
+        if (!firstFeature) out << ",\n";
+        firstFeature = false;
+
+        out << "{\"type\":\"Feature\",\"geometry\":"
+               "{\"type\":\"MultiPolygon\",\"coordinates\":[";
+        bool firstCell = true;
+        for (const GridIndex& gi : rec.indices)
+        {
+            if (!firstCell) out << ",";
+            firstCell = false;
+            double minx = rec.origin.x + gi.x() * 2.0;
+            double miny = rec.origin.y + gi.y() * 2.0;
+            double maxx = minx + 2.0;
+            double maxy = miny + 2.0;
+            out << "[["
+                << "[" << minx << "," << miny << "],"
+                << "[" << maxx << "," << miny << "],"
+                << "[" << maxx << "," << maxy << "],"
+                << "[" << minx << "," << maxy << "],"
+                << "[" << minx << "," << miny << "]"
+                << "]]";
+        }
+        out << "]},\"properties\":{"
+            << "\"scan\":\"" << (rec.isBefore ? "before" : "after") << "\","
+            << "\"tile_i\":" << rec.tile.first << ","
+            << "\"tile_j\":" << rec.tile.second << ","
+            << "\"shape_id\":" << rec.id << ","
+            << "\"size\":" << rec.indices.size() << ","
+            << "\"matched\":" << (rec.matched ? "true" : "false") << ",";
+        if (rec.matched)
+            out << "\"match_id\":" << rec.matchId;
+        else
+            out << "\"match_id\":null";
+        out << "}}";
+    }
+    out << "\n]}\n";
 }
 
 } // namespace

--- a/displacement/Atlas.cpp
+++ b/displacement/Atlas.cpp
@@ -176,7 +176,7 @@ void Atlas::load()
     splitterOpts.add("length", m_len);
     splitterOpts.add("origin_x", m_origin.x);
     splitterOpts.add("origin_y", m_origin.y);
-    splitterOpts.add("overlap", m_overlap);
+    splitterOpts.add("buffer", m_overlap);
 
     StageCreationOptions bOps { m_beforeFilename };
     Stage& beforeReader = m_beforeMgr.makeReader(bOps);
@@ -189,7 +189,7 @@ void Atlas::load()
     afterSplitterOpts.add("length", m_len);
     afterSplitterOpts.add("origin_x", m_origin.x + m_shift.x);
     afterSplitterOpts.add("origin_y", m_origin.y + m_shift.y);
-    afterSplitterOpts.add("overlap", m_overlap);
+    afterSplitterOpts.add("buffer", m_overlap);
 
     StageCreationOptions aOps { m_afterFilename };
     Stage& afterReader = m_afterMgr.makeReader(aOps);

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -90,6 +90,7 @@ private:
     std::vector<ShapeRecord> m_shapeRecords;
     std::string m_tiffDir;
     std::string m_geojsonDir;
+    std::string m_svgDir;
 };
 
 } // namespace

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -88,6 +88,8 @@ private:
     const double m_len = 100.0;
     const double m_overlap = 20.0;
     std::vector<ShapeRecord> m_shapeRecords;
+    std::string m_tiffDir;
+    std::string m_geojsonDir;
 };
 
 } // namespace

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -72,6 +72,7 @@ private:
     pdal::PipelineManager m_beforeMgr;
     pdal::PipelineManager m_afterMgr;
     const double m_len = 100.0;
+    const double m_overlap = 20.0;
 };
 
 } // namespace

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -20,6 +20,17 @@
 namespace AtlasProcessor
 {
 
+struct ShapeRecord
+{
+    std::vector<GridIndex> indices;
+    Point origin;
+    bool isBefore;
+    Coord tile;
+    size_t id;
+    bool matched;
+    size_t matchId;  // SIZE_MAX if unmatched
+};
+
 class Atlas
 {
 public:
@@ -49,6 +60,9 @@ private:
     void writeSvg(const std::string& filename, const pdal::BOX2D& extent);
     void read(const std::string& filename);
     bool shouldDump() const;
+    void recordShapes(GridPtr& g, bool isBefore, Coord tile, Point origin,
+        const std::vector<ShapePair>& matches);
+    void writeShapeGeoJSON(const std::string& filename);
 
     pdal::ProgramArgs m_args;
     std::string m_beforeFilename;
@@ -73,6 +87,7 @@ private:
     pdal::PipelineManager m_afterMgr;
     const double m_len = 100.0;
     const double m_overlap = 20.0;
+    std::vector<ShapeRecord> m_shapeRecords;
 };
 
 } // namespace

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -83,6 +83,7 @@ private:
     Point m_dumpxy;
     double m_dumpfrac;
     int m_minShape;
+    double m_gridLen;
 
     pdal::PipelineManager m_beforeMgr;
     pdal::PipelineManager m_afterMgr;

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -36,7 +36,7 @@ private:
     void dumpSurrounding();
     Coord splitterCoord(const Coord& c) const;
     std::vector<ShapePair> matchShapes(GridPtr& bg, GridPtr& ag, double threshold);
-    std::pair<Point, Point> calculateOffset(GridPtr& bg, GridPtr& ag,
+    std::tuple<Point, Point, double> calculateOffset(GridPtr& bg, GridPtr& ag,
         const std::vector<ShapePair>& shapes);
     void addArgs();
     void load();

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -35,13 +35,13 @@ private:
     void dumpShapes(GridPtr& g);
     void dumpSurrounding();
     Coord splitterCoord(const Coord& c) const;
-    std::vector<ShapePair> matchShapes(GridPtr& bg, GridPtr& ag);
+    std::vector<ShapePair> matchShapes(GridPtr& bg, GridPtr& ag, double threshold);
     std::pair<Point, Point> calculateOffset(GridPtr& bg, GridPtr& ag,
         const std::vector<ShapePair>& shapes);
     void addArgs();
     void load();
     void parse(const pdal::StringList& s);
-    bool process(Coord c, Point& offset);
+    bool process(Coord c, Point& offset, double spread);
     void processGrid();
     void throwError(const std::string& s);
     void writeSimple();

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -82,6 +82,7 @@ private:
     Coord m_dumpij;
     Point m_dumpxy;
     double m_dumpfrac;
+    int m_minShape;
 
     pdal::PipelineManager m_beforeMgr;
     pdal::PipelineManager m_afterMgr;

--- a/displacement/Atlas.hpp
+++ b/displacement/Atlas.hpp
@@ -36,7 +36,7 @@ private:
     void dumpSurrounding();
     Coord splitterCoord(const Coord& c) const;
     std::vector<ShapePair> matchShapes(GridPtr& bg, GridPtr& ag);
-    Point calculateOffset(GridPtr& bg, GridPtr& ag,
+    std::pair<Point, Point> calculateOffset(GridPtr& bg, GridPtr& ag,
         const std::vector<ShapePair>& shapes);
     void addArgs();
     void load();

--- a/displacement/CMakeLists.txt
+++ b/displacement/CMakeLists.txt
@@ -24,5 +24,5 @@ target_link_libraries(atlas
 
 target_compile_features(atlas
     PRIVATE
-        cxx_std_11
+        cxx_std_17
 )

--- a/displacement/Field.hpp
+++ b/displacement/Field.hpp
@@ -112,7 +112,10 @@ public:
     bool valid(Coord c)
     { return pos(c) >= 0; }
 
-    std::pair<bool, Point> initialOffset(Coord c)
+    // Returns {valid, estimated_offset, rms_spread_of_neighbors}.
+    // Spread is the weighted RMS deviation of neighbor offsets from the mean;
+    // used to set an adaptive match threshold in matchShapes.
+    std::tuple<bool, Point, double> initialOffset(Coord c)
     {
         const double Sqrt2Recip = 0.70710678118;
         double x = 0;
@@ -134,7 +137,7 @@ public:
         if (idx >= 0)
         {
             if (m_valid[idx])
-                return { true, { m_x[idx], m_y[idx] } };
+                return { true, { m_x[idx], m_y[idx] }, 0.0 };
 
             // We weight each full neighbor equally and each corner neighbor
             // by 1/sqrt(2)
@@ -150,10 +153,33 @@ public:
             {
                 x /= sum;
                 y /= sum;
-                return { true, { x, y } };
+
+                // Weighted RMS deviation of neighbors from the computed mean.
+                double variance = 0;
+                auto addVariance = [&](Coord nc, double rel)
+                {
+                    int nidx = pos(nc);
+                    if (nidx >= 0 && m_valid[nidx])
+                    {
+                        double dx = m_x[nidx] - x;
+                        double dy = m_y[nidx] - y;
+                        variance += rel * (dx * dx + dy * dy);
+                    }
+                };
+                addVariance(Coord(c.first + 1, c.second), 1);
+                addVariance(Coord(c.first - 1, c.second), 1);
+                addVariance(Coord(c.first, c.second + 1), 1);
+                addVariance(Coord(c.first, c.second - 1), 1);
+                addVariance(Coord(c.first + 1, c.second + 1), Sqrt2Recip);
+                addVariance(Coord(c.first - 1, c.second + 1), Sqrt2Recip);
+                addVariance(Coord(c.first + 1, c.second - 1), Sqrt2Recip);
+                addVariance(Coord(c.first - 1, c.second - 1), Sqrt2Recip);
+                double spread = std::sqrt(variance / sum);
+
+                return { true, { x, y }, spread };
             }
         }
-        return { false, { 0, 0 } };
+        return { false, { 0, 0 }, 3.0 };
     }
 
 private:

--- a/displacement/Field.hpp
+++ b/displacement/Field.hpp
@@ -20,6 +20,7 @@ class Field
 public:
     Field(size_t width, size_t height) : m_width(width), m_height(height),
         m_x(width * height), m_y(width * height), m_z(width * height),
+        m_medianX(width * height), m_medianY(width * height), m_medianZ(width * height),
         m_before(width * height), m_after(width * height), m_valid(width * height),
         m_maxLen2(std::numeric_limits<double>::lowest())
     {}
@@ -32,6 +33,15 @@ public:
 
     const float *zdata() const
     { return m_z.data(); }
+
+    const float *medianXdata() const
+    { return m_medianX.data(); }
+
+    const float *medianYdata() const
+    { return m_medianY.data(); }
+
+    const float *medianZdata() const
+    { return m_medianZ.data(); }
 
     const float *bdata() const
     { return m_before.data(); }
@@ -60,6 +70,17 @@ public:
         m_y[idx] = displacement.y;
         m_z[idx] = displacement.z;
         m_valid[idx] = true;
+    }
+
+    void setMedianOffset(Coord c, Point displacement)
+    {
+        size_t idx = pos(c);
+        if (idx < 0)
+            return;
+
+        m_medianX[idx] = displacement.x;
+        m_medianY[idx] = displacement.y;
+        m_medianZ[idx] = displacement.z;
     }
 
     void setBeforeCount(Coord c, float count)
@@ -143,6 +164,9 @@ private:
     std::vector<float> m_x;
     std::vector<float> m_y;
     std::vector<float> m_z;
+    std::vector<float> m_medianX;
+    std::vector<float> m_medianY;
+    std::vector<float> m_medianZ;
     std::vector<float> m_before;
     std::vector<float> m_after;
     std::vector<bool> m_valid;

--- a/displacement/Field.hpp
+++ b/displacement/Field.hpp
@@ -67,7 +67,7 @@ public:
 
     void setOffset(Coord c, Point displacement)
     {
-        size_t idx = pos(c);
+        int idx = pos(c);
         if (idx < 0)
             return;
 
@@ -81,7 +81,7 @@ public:
 
     void setMatchQuality(Coord c, int count, float rms)
     {
-        size_t idx = pos(c);
+        int idx = pos(c);
         if (idx < 0)
             return;
 
@@ -91,7 +91,7 @@ public:
 
     void setMedianOffset(Coord c, Point displacement)
     {
-        size_t idx = pos(c);
+        int idx = pos(c);
         if (idx < 0)
             return;
 
@@ -102,7 +102,7 @@ public:
 
     void setBeforeCount(Coord c, float count)
     {
-        size_t idx = pos(c);
+        int idx = pos(c);
         if (idx < 0)
             return;
 
@@ -111,7 +111,7 @@ public:
 
     void setAfterCount(Coord c, float count)
     {
-        size_t idx = pos(c);
+        int idx = pos(c);
         if (idx < 0)
             return;
 
@@ -120,7 +120,7 @@ public:
 
     Point offset(Coord c)
     {
-        size_t idx = pos(c);
+        int idx = pos(c);
         if (idx < 0)
             return Point();
         return Point(m_x[idx], m_y[idx], m_z[idx]);

--- a/displacement/Field.hpp
+++ b/displacement/Field.hpp
@@ -22,6 +22,7 @@ public:
         m_x(width * height), m_y(width * height), m_z(width * height),
         m_medianX(width * height), m_medianY(width * height), m_medianZ(width * height),
         m_before(width * height), m_after(width * height), m_valid(width * height),
+        m_matchCount(width * height), m_rmsResidual(width * height),
         m_maxLen2(std::numeric_limits<double>::lowest())
     {}
 
@@ -49,6 +50,12 @@ public:
     const float *adata() const
     { return m_after.data(); }
 
+    const float *matchCountData() const
+    { return m_matchCount.data(); }
+
+    const float *rmsResidualData() const
+    { return m_rmsResidual.data(); }
+
     size_t width() const
     { return m_width; }
 
@@ -70,6 +77,16 @@ public:
         m_y[idx] = displacement.y;
         m_z[idx] = displacement.z;
         m_valid[idx] = true;
+    }
+
+    void setMatchQuality(Coord c, int count, float rms)
+    {
+        size_t idx = pos(c);
+        if (idx < 0)
+            return;
+
+        m_matchCount[idx] = static_cast<float>(count);
+        m_rmsResidual[idx] = rms;
     }
 
     void setMedianOffset(Coord c, Point displacement)
@@ -195,6 +212,8 @@ private:
     std::vector<float> m_medianZ;
     std::vector<float> m_before;
     std::vector<float> m_after;
+    std::vector<float> m_matchCount;
+    std::vector<float> m_rmsResidual;
     std::vector<bool> m_valid;
     double m_maxLen2;
 

--- a/displacement/Grid.hpp
+++ b/displacement/Grid.hpp
@@ -84,7 +84,7 @@ public:
 private:
     GridCell m_emptyCell;
     pdal::PointViewPtr m_view;
-    int m_len;
+    double m_len;
     Point m_origin;
     std::unordered_map<GridIndex, GridCell> m_cells;
     std::vector<Shape> m_shapes;

--- a/displacement/build.sh
+++ b/displacement/build.sh
@@ -6,5 +6,6 @@ mkdir build
 cd build
 cmake -G Ninja ..  \
     -DCMAKE_BUILD_TYPE=Release  \
-    -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+    -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+    -DCMAKE_CXX_COMPILER=$CXX
 ninja

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+name: pdal_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  # C++ build toolchain
+  - compilers
+  - cmake
+  - ninja
+  - eigen
+  # PDAL + GDAL (core data I/O)
+  - pdal
+  - python-pdal
+  - gdal
+  # Python utilities
+  - python=3.13
+  - numpy
+  - pip
+  - pip:
+      - pdal-plugins


### PR DESCRIPTION
I (and Claude) made several improvements for stability. 

1. Taking median instead of the mean of each cell
2. Shape size filter
3. changing the internal tile grid from 2 m -> 1 m
4. adding several new bands for uncertainty 

 | Band | Name         | Description                               |
  |------|--------------|-------------------------------------------|
  | 1    | X            | Mean X displacement (m)                   |
  | 2    | Y            | Mean Y displacement (m)                   |
  | 3    | Z            | Mean Z displacement (m)                   |
  | 4    | BEFORE       | Point count before scan                   |
  | 5    | AFTER        | Point count after scan                    |
  | 6    | MEDIAN_X     | Median X displacement (m)                 |
  | 7    | MEDIAN_Y     | Median Y displacement (m)                 |
  | 8    | MEDIAN_Z     | Median Z displacement (m)                 |
  | 9    | MATCH_COUNT  | Number of matched shape pairs             |
  | 10   | RMS_RESIDUAL | RMS deviation of matched pairs from mean  |